### PR TITLE
Adjust Group B Aspen schedule for 9pm DEN flight

### DIFF
--- a/colorado-trip/index.html
+++ b/colorado-trip/index.html
@@ -1187,7 +1187,7 @@
           <div class="stop-dot"></div>
           <div class="stop-top">
             <span class="stop-name">Aspen + Maroon Bells</span>
-            <span class="stop-time">1:30pm – 5:00pm</span>
+            <span class="stop-time">1:30pm – 3:15pm</span>
           </div>
           <div class="carousel" data-autoplay>
             <div class="carousel-track">
@@ -1199,7 +1199,7 @@
             <button class="carousel-btn carousel-next">&#8250;</button>
             <div class="carousel-dots"><span class="dot active"></span><span class="dot"></span><span class="dot"></span></div>
           </div>
-          <div class="stop-desc"><strong>Maroon Bells</strong> — the most photographed peaks in North America. Twin 14,000ft summits reflected in Maroon Lake. Easy 1.8mi loop trail around the lake, or just the viewpoint. <strong>Shuttle required in summer</strong> — take the Roaring Fork Transit Authority bus from Aspen (~$8 roundtrip, runs hourly). Back in Aspen: great town for lunch/coffee — try <strong>Cache Cache</strong> for French bistro or grab a pastry at <strong>Jour de Fête</strong>. Aspen is fancy but walkable and the mountains are free.</div>
+          <div class="stop-desc"><strong>Maroon Bells</strong> — the most photographed peaks in North America. Twin 14,000ft summits reflected in Maroon Lake. Easy 1.8mi loop trail around the lake, or just the viewpoint. <strong>Shuttle required in summer</strong> — take the Roaring Fork Transit Authority bus from Aspen (~$8 roundtrip, runs hourly). Back in Aspen: great town for a quick lunch/coffee — try <strong>Cache Cache</strong> for French bistro or grab a pastry at <strong>Jour de Fête</strong>. Aspen is fancy but walkable and the mountains are free. <strong>Note:</strong> with a 9pm DEN flight, leave Aspen by 3:30pm — that gives you 3.5hrs of drive time and a comfortable 2hr airport buffer.</div>
           <div class="stop-tags">
             <span class="tag tag-scenic">Iconic</span>
             <span class="tag tag-hike">Easy Walk</span>
@@ -1223,9 +1223,9 @@
           <div class="stop-dot"></div>
           <div class="stop-top">
             <span class="stop-name">Return car + Depart DEN</span>
-            <span class="stop-time">Arrive ~9:30pm</span>
+            <span class="stop-time">Arrive ~7:00pm · Flight 9:00pm</span>
           </div>
-          <div class="stop-desc">Leave Aspen by ~5:30pm, arrive Denver ~9pm. Drop car at DEN. Book an evening or early Tuesday morning flight — plenty of buffer.</div>
+          <div class="stop-desc">Leave Aspen by 3:30pm — 3.5hr drive puts you at DEN by ~7:00pm. Drop rental car, check in, and clear security with ~2hrs to spare before your 9pm flight.</div>
           <div class="stop-tags">
             <span class="tag tag-culture">Group B departs</span>
           </div>


### PR DESCRIPTION
Trims the Aspen + Maroon Bells window and updates the departure card so Group B can comfortably make a 9pm DEN flight.

- Aspen stop: `1:30pm – 5:00pm` → `1:30pm – 3:15pm`
- Added inline note to leave Aspen by 3:30pm (3.5hr drive + 2hr airport buffer)
- Departure card: `Arrive ~9:30pm` → `Arrive ~7:00pm · Flight 9:00pm`

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1SLyLHfgXpASZmuswbTe9)_